### PR TITLE
Do not redirect / to /index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "landing-page",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "That landing page you can use :)",
   "main": "server.js",
   "scripts": {
     "start": "node server.js"
   },
-  "homepage": "https://github.com/sroze/landing-page",
+  "homepage": "https://github.com/continuouspipe/landing-page",
   "dependencies": {
     "express": "^4.1.2",
     "body-parser": "^1.1.2",

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ var express = require("express"),
     publicDir = process.argv[2] || __dirname + '/public';
 
 app.get("/", function (req, res) {
-  res.redirect("/index.html");
+  res.sendfile('index.html', { root: publicDir } );
 });
 
 app.use(methodOverride());


### PR DESCRIPTION
When using this image as a holding page for PHP applications, /index.html is usually a 404, instead /index.php is usually the destination.